### PR TITLE
remove ZERO WIDTH SPACE

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -58,7 +58,7 @@ Formatting a .tex file actually changes it on the disk and then if `latex-worksh
 
 ## Large bibtex files are ignored
 
-Bibtex files listed in a project are parsed for citation completion. This may induce significant slow down with large bibtex files. You can configure the maximum size of bibtex files parsed by the extension with [`latex-workshop​.intellisense​.citation​.maxfilesizeMB"`](Intelissense#latex-workshopintellisensecitationmaxfilesizeMB).
+Bibtex files listed in a project are parsed for citation completion. This may induce significant slow down with large bibtex files. You can configure the maximum size of bibtex files parsed by the extension with [`latex-workshop.intellisense.citation.maxfilesizeMB"`](Intelissense#latex-workshopintellisensecitationmaxfilesizeMB).
 
 ## Path containing Chinese characters
 


### PR DESCRIPTION
A patch to remove ZERO WIDTH SPACE, `0xE2 0x80 0x8B`.

![2018-12-29 20 01 41](https://user-images.githubusercontent.com/10665499/50537604-419f9e80-0ba5-11e9-8a35-e17e16dbf430.png)

![2018-12-29 20 05 33](https://user-images.githubusercontent.com/10665499/50537615-58de8c00-0ba5-11e9-8fca-723161ae3e9f.png)
