### PR TITLE
Add a bunch of zero width spaces

### DIFF
--- a/Compile.md
+++ b/Compile.md
@@ -8,26 +8,26 @@ You can define several compiling toolchains to build LaTeX projects using [LaTeX
 
 The following settings are helpful to customize how to build a project and how to deal with failures.
 
-|                       Setting key                        |                     Description                      | Default |        Type        |
-| -------------------------------------------------------- | ---------------------------------------------------- | ------- | ------------------ |
-| `latex-workshop.latex.autoBuild.onSave.enabled`          | Enable automatic building when saving any tex file   | `true`  | _boolean_          |
-| `latex-workshop.latex.autoBuild.onTexChange.enabled`     | Enable LaTeX building after any tex file has changed | `false` | _boolean_          |
-| [`latex-workshop.latex.recipes`](#latex-recipe)          | Sequence of tools to run for building                |         | _JSON object_      |
-| [`latex-workshop.latex.tools`](#latex-recipe)            | Tools available for building                         |         | _JSON object_      |
-| [`latex-workshop.latex.magic.args`](#magic-comments)     | Arguments for the `TeX program`                      |         | _array of strings_ |
-| [`latex-workshop.latex.magic.bib.args`](#magic-comments) | Arguments for the `BIB program`                      |         | _array of strings_ |
+| Setting key                                                  | Description                                          | Default | Type               |
+| ------------------------------------------------------------ | ---------------------------------------------------- | ------- | ------------------ |
+| `latex-workshop​.latex​.autoBuild​.onSave​.enabled`          | Enable automatic building when saving any tex file   | `true`  | _boolean_          |
+| `latex-workshop​.latex​.autoBuild​.onTexChange​.enabled`     | Enable LaTeX building after any tex file has changed | `false` | _boolean_          |
+| [`latex-workshop​.latex​.recipes`](#latex-recipe)            | Sequence of tools to run for building                |         | _JSON object_      |
+| [`latex-workshop​.latex​.tools`](#latex-recipe)              | Tools available for building                         |         | _JSON object_      |
+| [`latex-workshop​.latex​.magic​.args`](#magic-comments)      | Arguments for the `TeX program`                      |         | _array of strings_ |
+| [`latex-workshop​.latex​.magic​.bib​.args`](#magic-comments) | Arguments for the `BIB program`                      |         | _array of strings_ |
 
 ## Cleaning generated files
 
 LaTeX compilation typically generates several auxiliary files. They can be removed by calling _Clean up auxiliary files_ from the _Command Palette_ or from the _TeX_ badge. This command is bind to <kbd>ctrl</kbd>+<kbd>alt</kbd>+<kbd>c</kbd>. If you cannot use <kbd>ctrl</kbd>+<kbd>alt</kbd> in a keybinding, see[the FAQ](FAQ#i-cannot-use-ctrlalt-in-a-shortcut).
 
-|                     Setting key                      |                    Description                    | Default |  Type   |
-| ---------------------------------------------------- | ------------------------------------------------- | ------- | ------- |
-| `latex-workshop.latex.autoBuild.cleanAndRetry.enabled` | Enable cleaning and building once more after errors in the build toolchain | `true` | _boolean_ |
-| `latex-workshop.latex.clean.enabled` | Enable cleaning LaTeX auxiliary files after building project | `false` | _boolean_ |
-| `latex-workshop.latex.clean.onFailBuild.enabled` | Enable cleaning LaTeX auxiliary files after a failed build | `false` | _boolean_ |
-| `latex-workshop.latex.clean.fileTypes` | Extensions of files to clean |  | _array of strings_ |
-| `latex-workshop.latex.clean.subfolder.enabled` | Clean LaTeX auxillary files recursively in sub-folders of [`latex-workshop.latex.outDir`](View#latex-workshoplatexoutDir) | false | _boolean_ |
+| Setting key                                                | Description                                                                                                                 | Default | Type               |
+| ---------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- | ------- | ------------------ |
+| `latex-workshop​.latex​.autoBuild​.cleanAndRetry​.enabled` | Enable cleaning and building once more after errors in the build toolchain                                                  | `true`  | _boolean_          |
+| `latex-workshop​.latex​.clean​.enabled`                    | Enable cleaning LaTeX auxiliary files after building project                                                                | `false` | _boolean_          |
+| `latex-workshop​.latex​.clean​.onFailBuild​.enabled`       | Enable cleaning LaTeX auxiliary files after a failed build                                                                  | `false` | _boolean_          |
+| `latex-workshop​.latex​.clean​.fileTypes`                  | Extensions of files to clean                                                                                                |         | _array of strings_ |
+| `latex-workshop​.latex​.clean​.subfolder​.enabled`         | Clean LaTeX auxillary files recursively in sub-folders of [`latex-workshop​.latex​.outDir`](View#latex-workshoplatexoutDir) | false   | _boolean_          |
 
 ## LaTeX recipes
 
@@ -96,7 +96,6 @@ You can create multiple recipes with different tools. Each recipe is an object i
 
 The `tools` in recipes can be defined in `latex-workshop.latex.tools`, in which each command is a `tool`. Each tool is an object consists of a `name`, a `command` to be spawned, and its arguments (`args`). To include a tool in a recipe, the tool's `name` should be included in the recipe's `tools` list.
 
-
 When building the project, the first recipe is used. You can compile with another recipe by command `latex-workshop.recipes`. By default [`latexmk`](http://personal.psu.edu/jcc8/software/latexmk/) is used. This tool is bundled in most LaTeX distributions, and requires perl to execute. For non-perl users, the following `texify` toolchain from MikTeX may worth a try:
 
 ```
@@ -121,13 +120,13 @@ When building the project, the first recipe is used. You can compile with anothe
 
 As you may notice, there is a mystic `%DOC%` in the arguments. Symbols surrounded by `%` are placeholders, which are replaced with its representing string on-the-fly. LaTeX Workshop registers the following placeholders:
 
-| Placeholder |                                               Replaced by                                                |
-| ----------- | -------------------------------------------------------------------------------------------------------- |
-| `%DOC%`     | The LaTeX root file path and name without the `.tex` extension                                           |
-| `%DOCFILE%` | The LaTeX root file name without the `.tex` extension                                                    |
-| `%DIR%`     | The LaTeX root file path                                                                                 |
-| `%TMPDIR%`  | A temporary folder for storing ancillary files                                                           |
-| `%OUTDIR%`  | The output directory configured in [`latex-workshop.latex.outDir`](View#latex-workshoplatexoutDir) |
+| Placeholder | Replaced by                                                                                          |
+| ----------- | ---------------------------------------------------------------------------------------------------- |
+| `%DOC%`     | The LaTeX root file path and name without the `.tex` extension                                       |
+| `%DOCFILE%` | The LaTeX root file name without the `.tex` extension                                                |
+| `%DIR%`     | The LaTeX root file path                                                                             |
+| `%TMPDIR%`  | A temporary folder for storing ancillary files                                                       |
+| `%OUTDIR%`  | The output directory configured in [`latex-workshop​.latex​.outDir`](View#latex-workshoplatexoutDir) |
 
 Alternatively, you can also set your commands without the placeholder, just like what you may input in a terminal.
 As most LaTeX compiler accepts root file name without extension, `%DOC%` and `%DOCFILE%` do not include `.tex` extension. Meanwhile, `texify` requires the extension. So in the above tool `%DOC%` and `.tex` are concatenated for completeness.
@@ -187,9 +186,9 @@ Show badbox information in the problems panel.
 
 Exclude log messages that matches the given regexp from the problems panel.
 
-|       type        | default value |
-| ----------------- | ------------- |
-| _array of strings | `[]`          |
+| type               | default value |
+| ------------------ | ------------- |
+| \_array of strings | `[]`          |
 
 ### latex-workshop.message.information.show
 

--- a/Hover.md
+++ b/Hover.md
@@ -2,7 +2,7 @@
 
 ## Documentation of a package
 
-To open a package documentation, hover the package name inside the `\usepackage` call and click on the _View documentation_ link. As it internally calls `texdoc`, if it is not in your path you may need to set [`latex-workshop.texdoc.path`](latex-workshoptexdocpath) to the full path of `texdoc`.
+To open a package documentation, hover the package name inside the `\usepackage` call and click on the _View documentation_ link. As it internally calls `texdoc`, if it is not in your path you may need to set [`latex-workshop​.texdoc​.path`](latex-workshoptexdocpath) to the full path of `texdoc`.
 
 <img src="https://github.com/James-Yu/LaTeX-Workshop/raw/master/demo_media/hover-package.gif" alt="Hover on a package demo">
 
@@ -10,7 +10,7 @@ You may also directly run the _LaTex Workshop: Show package documentation_ comma
 
 ## Previewing equations
 
-When you move the mouse cursor over inline math,  `\[`,  `\begin{align}`, and `\begin{...}` of other math environments, math preview on hover is rendered. When you move the mouse cursor over `\ref`, and other reference commands referring math equations, math preview on hover is also rendered.
+When you move the mouse cursor over inline math, `\[`, `\begin{align}`, and `\begin{...}` of other math environments, math preview on hover is rendered. When you move the mouse cursor over `\ref`, and other reference commands referring math equations, math preview on hover is also rendered.
 
 <img src="https://github.com/James-Yu/LaTeX-Workshop/raw/master/demo_media/hover.gif" alt="Preview maths demo" height="120px">
 
@@ -20,19 +20,19 @@ Supported math environments are `align`, `align*`, `alignat`, `alignat*`, `align
 
 ## Previewing citation details
 
-When [`latex-workshop.hoverCitation.enabled`](#latex-workshophoverCitationenabled) is set to `true`, moving the mouse over an argument of a `\cite` related command displays the details of the bibliography as a tooltip.
+When [`latex-workshop​.hoverCitation​.enabled`](#latex-workshophoverCitationenabled) is set to `true`, moving the mouse over an argument of a `\cite` related command displays the details of the bibliography as a tooltip.
 
 <img src="https://github.com/James-Yu/LaTeX-Workshop/raw/master/demo_media/hover-cite.gif" alt="Hover on \cite demo">
 
 ## Previewing references
 
-When [`latex-workshop.hoverReference.enabled`](#latex-workshophoverReferenceenabled) is set to `true`, moving the mouse over a `\ref` related command displays the piece of `tex` with the corresponding label as a tooltip. Moreover, if the label refers to a maths environment as described in [Preview equations](#Preview-equations) and [`latex-workshop.hoverPreview.ref.enabled`](#latex-workshophoverPreviewrefenabled) is set to `true`, math preview is rendered instead of showing the tex content.
+When [`latex-workshop​.hoverReference​.enabled`](#latex-workshophoverReferenceenabled) is set to `true`, moving the mouse over a `\ref` related command displays the piece of `tex` with the corresponding label as a tooltip. Moreover, if the label refers to a maths environment as described in [Preview equations](#Preview-equations) and [`latex-workshop​.hoverPreview​.ref​.enabled`](#latex-workshophoverPreviewrefenabled) is set to `true`, math preview is rendered instead of showing the tex content.
 
 <img src="https://github.com/James-Yu/LaTeX-Workshop/raw/master/demo_media/hover-ref.gif" alt="Hover on \ref demo" height="300px">
 
 ## Documentation of a command
 
-When [`latex-workshop.hoverCommandDoc.enabled`](#latex-workshophoverCommandDocenabled) is set to `true`, moving the mouse over a command displays the different forms (signatures) of the command with their arguments as a tooltip. You can directly access the documentation of the package(s) defining the command by clicking on the package name(s).
+When [`latex-workshop​.hoverCommandDoc​.enabled`](#latex-workshophoverCommandDocenabled) is set to `true`, moving the mouse over a command displays the different forms (signatures) of the command with their arguments as a tooltip. You can directly access the documentation of the package(s) defining the command by clicking on the package name(s).
 
 <img src="https://github.com/James-Yu/LaTeX-Workshop/raw/master/demo_media/hover-command.gif" alt="Hover on a command demo">
 
@@ -74,9 +74,9 @@ Enable math preview on hover.
 
 Scale of math preview on hover.
 
-| type      | default value |
-| --------- | ------------- |
-| _number_  | 1             |
+| type     | default value |
+| -------- | ------------- |
+| _number_ | 1             |
 
 ### latex-workshop.hoverPreview.cursor.enabled
 
@@ -90,19 +90,19 @@ Render cursor in math preview on hover at the current position.
 
 Define the cursor symbol in math preview on hover.
 
-| type      | default value |
-| --------- | ------------- |
-| _string_ | `\ddagger`     |
+| type     | default value |
+| -------- | ------------- |
+| _string_ | `\ddagger`    |
 
 ### latex-workshop.hoverPreview.cursor.color
 
 Define the color of the cursor in math preview on hover.
 
-| type      | default value |
-| --------- | ------------- |
-| _string_  | "auto"        |
+| type     | default value |
+| -------- | ------------- |
+| _string_ | "auto"        |
 
-The possible values are : ` "auto" | "black" | "blue" | "brown" | "cyan" | "darkgray" | "gray" | "green" | "lightgray" | "lime" | "magenta" | "olive" | "orange" | "pink" | "purple" | "red" | "teal" | "violet" | "white" | "yellow"`.
+The possible values are: `"auto" | "black" | "blue" | "brown" | "cyan" | "darkgray" | "gray" | "green" | "lightgray" | "lime" | "magenta" | "olive" | "orange" | "pink" | "purple" | "red" | "teal" | "violet" | "white" | "yellow"`.
 
 ### latex-workshop.hoverPreview.ref.enabled
 
@@ -116,8 +116,8 @@ Render math preview on hover over `\ref`, and other reference commands.
 
 PDF viewer used for `[View on PDF]` link on hover over `\ref`, and other reference commands.
 
-| type      | default value |
-| --------- | ------------- |
-| _string_  | "auto"        |
+| type     | default value |
+| -------- | ------------- |
+| _string_ | "auto"        |
 
 The possible values are : `"auto" | "tabOrBrowser" | "external"`.

--- a/Intellisense.md
+++ b/Intellisense.md
@@ -10,15 +10,14 @@ Then, when citation commands like `\cite` and its derivatives are automatically 
 
 If you use very large bibtex files, you may experience temporary freezing. Hence, files larger than 5MB are ignored (see [`latex-workshop.intellisense.citation.maxfilesizeMB"`](#latex-workshopintellisensecitationmaxfilesizeMB)).
 
-|                                                 Setting key                                                  |                                      Description                                       |    Default     |           Type           | 
-| ------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------- | -------------- | ------------------------ |
-| [`latex-workshop.intellisense.citation.label`](#latex-workshopintellisensecitationlabel)                  | Citation property used as suggestion                                                   | `"bibtex key"` | _string_: "bibtex key" \| "title" \| "authors" |
-| [`latex-workshop.intellisense.citation.maxfilesizeMB"`](#latex-workshopintellisensecitationmaxfilesizeMB) | Maximum bibtex file size (in MB)                                                       | `5`            | _float_                  |
-| [`latex-workshop.intellisense.citation.type`](#latex-workshopintellisensecitationtype)                    | Type of vs code suggestion to use                                                      | `"inline"`     | _string_: "inline" \| "browser" (dropdown menu) |
-| [`latex-workshop.intellisense.package.enabled`](#latex-workshopintellisensepackageenabled)                | Enabling of auto-completion for commands and environments from loaded packages         | `false`        | _boolean_|
-| [`latex-workshop.latex.additionalBib`](#latex-workshoplatexadditionalBib)                                 | Additional bib paths to watch, both relative and absolute paths (with globs) supported ** Deprecated in favor of [`latex-workshop.latex.bibDirs`](#latex-workshoplatexbibDirs) **  | `[]`           | _array_ of _strings_     |
-| [`latex-workshop.latex.bibDirs`](#latex-workshoplatexbibDirs)                                             | List of paths to look for `.bib` files.  | `[]`           | _array_ of _strings_     |
-
+| Setting key                                                                                                  | Description                                                                                                                                                                         | Default        | Type                                            |
+| ------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- | ----------------------------------------------- |
+| [`latex-workshop​.intellisense​.citation​.label`](#latex-workshopintellisensecitationlabel)                  | Citation property used as suggestion                                                                                                                                                | `"bibtex key"` | _string_: "bibtex key" \| "title" \| "authors"  |
+| [`latex-workshop​.intellisense​.citation​.maxfilesizeMB"`](#latex-workshopintellisensecitationmaxfilesizeMB) | Maximum bibtex file size (in MB)                                                                                                                                                    | `5`            | _float_                                         |
+| [`latex-workshop​.intellisense​.citation​.type`](#latex-workshopintellisensecitationtype)                    | Type of vs code suggestion to use                                                                                                                                                   | `"inline"`     | _string_: "inline" \| "browser" (dropdown menu) |
+| [`latex-workshop​.intellisense​.package​.enabled`](#latex-workshopintellisensepackageenabled)                | Enabling of auto-completion for commands and environments from loaded packages                                                                                                      | `false`        | _boolean_                                       |
+| [`latex-workshop​.latex​.additionalBib`](#latex-workshoplatexadditionalBib)                                  | Additional bib paths to watch, both relative and absolute paths (with globs) supported ** Deprecated in favor of [`latex-workshop​.latex​.bibDirs`](#latex-workshoplatexbibDirs) ** | `[]`           | _array_ of _strings_                            |
+| [`latex-workshop​.latex​.bibDirs`](#latex-workshoplatexbibDirs)                                              | List of paths to look for `​.bib` files​.                                                                                                                                           | `[]`           | _array_ of _strings_                            |
 
 ## References
 
@@ -32,22 +31,19 @@ The key `\` automatically triggers completion of LaTeX commands. Several mechani
 
 - A set of standard LaTeX commands is provided.
 - The files of a LaTeX project are searched for any already used commands in the form `mycommand` followed by several `{}` groups. Then, a snippet is dynamically built for each of them and they are added to command completion list.
-- When [`latex-workshop.intellisense.package.enabled`](#latex-workshopintellisensepackageenabled) is `true`, the command completion list is also populated with the commands provided by all the package used in the project (through `\usepackage`). The list of commands provided by every package is described [here](https://github.com/LaTeXing/LaTeX-cwl).
+- When [`latex-workshop​.intellisense​.package​.enabled`](#latex-workshopintellisensepackageenabled) is `true`, the command completion list is also populated with the commands provided by all the package used in the project (through `\usepackage`). The list of commands provided by every package is described [here](https://github.com/LaTeXing/LaTeX-cwl).
 - The completion list can use either placeholders or tabstops. The default is to use tabstops, but it can be changed using [`latex-workshop.intellisense.useTabStops.enabled`](#latex-workshopintellisenseuseTabStopsenabled).
-    - placeholders: they provide meaningful information on the arguments but prevent any autocompletion trigger.
-    - tabstops: they enable us to directly trigger autocompletion again for citations and references.
+  - placeholders: they provide meaningful information on the arguments but prevent any autocompletion trigger.
+  - tabstops: they enable us to directly trigger autocompletion again for citations and references.
 - We provide one entry in the intellisense completion list per LaTeX command signature. If you feel, it makes the completion list too long, set [`latex-workshop.intellisense.optionalArgsEntries.enabled`](#latex-workshopintellisenseoptionalArgsEntries) to `false`.
 
-
-
-
-|                                                 Setting key                                                  |                                  Description                                   | Default |   Type    |
-| ------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------ | ------- | --------- |
-| [`latex-workshop.intellisense.package.enabled`](#latex-workshopintellisensepackageenabled)                   | Enabling of auto-completion for commands and environments from loaded packages | `false` | _boolean_ |
-| [`latex-workshop.intellisense.surroundCommand.enabled`](#latex-workshopintellisensesurroundCommandenabled) **Deprecated see [there](https://github.com/James-Yu/LaTeX-Workshop/wiki/Snippets#surrounding-text)**  | When text selected, set hotkey `\` surround selection with LaTeX command       | `false` | _boolean_ |
-| [`latex-workshop.intellisense.unimathsymbols.enabled`](#latex-workshopintellisenseunimathsymbolsenabled)     | Show unimath symbols as suggestions when `\` pressed                           | `false` | _boolean_ |
-| [`latex-workshop.intellisense.useTabStops.enabled`](#latex-workshopintellisenseuseTabStopsenabled)           | Use tabstops in intellisense completion                                        | `true`  | _boolean_ |
-| [`latex-workshop.intellisense.optionalArgsEntries.enabled`](#latex-workshopintellisenseoptionalArgsEntries)  | Add one completion item per command signature                                  | `true`  | _boolean_ |
+| Setting key                                                                                                                                                                                                          | Description                                                                                    | Default | Type      |
+| -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- | ------- | --------- |
+| [`latex-workshop​.intellisense​.package​.enabled`](#latex-workshopintellisensepackageenabled)                                                                                                                        | Enabling of auto-completion for commands and environments from loaded packages                 | `false` | _boolean_ |
+| [`latex-workshop​.intellisense​.surroundCommand​.enabled`](#latex-workshopintellisensesurroundCommandenabled) **Deprecated see [there](https://github​.com/James-Yu/LaTeX-Workshop/wiki/Snippets#surrounding-text)** | When text selected, set hotkey `\` surround selection with LaTeX command | `false` | _boolean_ |
+| [`latex-workshop​.intellisense​.unimathsymbols​.enabled`](#latex-workshopintellisenseunimathsymbolsenabled)                                                                                                          | Show unimath symbols as suggestions when `\` pressed | `false` | _boolean_                     |
+| [`latex-workshop​.intellisense​.useTabStops​.enabled`](#latex-workshopintellisenseuseTabStopsenabled)                                                                                                                | Use tabstops in intellisense completion                                                        | `true`  | _boolean_ |
+| [`latex-workshop​.intellisense​.optionalArgsEntries​.enabled`](#latex-workshopintellisenseoptionalArgsEntries)                                                                                                       | Add one completion item per command signature                                                  | `true`  | _boolean_ |
 
 ## Configuration variables
 
@@ -90,7 +86,6 @@ Auto-complete commands and environments from used packages.
 | --------- | ------------- |
 | _boolean_ | `false`       |
 
-
 ### latex-workshop.intellisense.optionalArgsEntries.enabled
 
 Many LaTeX commands can have several signatures, each with different arguments. If set to True, the intellisense completion list will have one entry for each form of a given command.
@@ -99,14 +94,13 @@ Many LaTeX commands can have several signatures, each with different arguments. 
 | --------- | ------------- |
 | _boolean_ | `true`        |
 
-
 ### latex-workshop.intellisense.useTabStops.enabled
 
 Use tabstops instead of placeholders in intellisense. Tabstops enable us to directly trigger autocompletion again (particularly useful for citations and references). On the contrary, placeholders prevent any direct call to autocompletion but they provide more information on the arguments meaning.
 
 | type      | default value |
 | --------- | ------------- |
-| _boolean_ | `true`       |
+| _boolean_ | `true`        |
 
 Reload vscode after change.
 

--- a/View.md
+++ b/View.md
@@ -98,7 +98,7 @@ Synctex may fail if the path contains non-ASCII characters, see [FAQ](FAQ#Path-c
 | [`latex-workshop​.synctex​.afterBuild​.enabled`](#latex-workshopsynctexafterBuildenabled) | Forward synctex at cursor after compiling | `false`       | _boolean_     |
 | [`latex-workshop​.synctex​.path`](#latex-workshopsynctexpath)                             | SyncTeX location                          | `"synctex"`   | _string_      |
 | [`latex-workshop​.view.pdf​.external​.synctex`](#latex-workshopviewpdfexternalsynctex)    | SyncTeX command for the external viewer   | (see details) | _JSON object_ |
-| [`latex-workshop.synctex.synctexjs.enabled`](#latex-workshopsynctexsynctexjsenabled)      | Enable using a built-in synctex function. | `true`        | _boolean_     |
+| [`latex-workshop​.synctex​.synctexjs​.enabled`](#latex-workshopsynctexsynctexjsenabled)   | Enable using a built-in synctex function. | `true`        | _boolean_     |
 
 ## Relevant Settings
 

--- a/View.md
+++ b/View.md
@@ -8,12 +8,12 @@ A document can previewed a number of ways, namely the icon that appears in the t
 
 ## Overview
 
-|                                     Setting key                                     |                    Description                    |    Default    |     Type      |
-| ----------------------------------------------------------------------------------- | ------------------------------------------------- | ------------- | ------------- |
-| [`latex-workshop​.latex.outDir`](#latex-workshoplatexoutDir)                   | Where to find the PDF files                       | `"%DIR%"`        | _string_      |
-| [`latex-workshop.view.pdf.viewer`](#latex-workshopviewpdfviewer)                    | The default PDF viewer                            | (see details) | _string_      |
-| [`latex-workshop.view.pdf.external.command`](#latex-workshopviewpdfexternalcommand) | The command to execute when using external viewer | (see details) | _JSON object_ |
-| [`latex-workshop.view.pdf.ref.viewer`](#latex-workshopviewpdfrefviewer)             | The PDF viewer to preview `\ref`                  | (see details) | _string_      |
+| Setting key                                                                             | Description                                       | Default       | Type          |
+| --------------------------------------------------------------------------------------- | ------------------------------------------------- | ------------- | ------------- |
+| [`latex-workshop​​.latex​.outDir`](#latex-workshoplatexoutDir)                          | Where to find the PDF files                       | `"%DIR%"`     | _string_      |
+| [`latex-workshop​.view​.pdf​.viewer`](#latex-workshopviewpdfviewer)                     | The default PDF viewer                            | (see details) | _string_      |
+| [`latex-workshop​.view​.pdf​.external​.command`](#latex-workshopviewpdfexternalcommand) | The command to execute when using external viewer | (see details) | _JSON object_ |
+| [`latex-workshop​.view​.pdf​.ref​.viewer`](#latex-workshopviewpdfrefviewer)             | The PDF viewer to preview `\ref`                  | (see details) | _string_      |
 
 ## Internal PDF viewer
 
@@ -23,13 +23,13 @@ You can customize the look and feel of the internal PDF viewer. Of course, this 
 
 Below are the detailed explanations for the different possible settings
 
-|                               Setting key                                |                Description                |
-| ------------------------------------------------------------------------ | ----------------------------------------- |
-| [`latex-workshop.view.pdf.zoom`](#latex-workshopviewpdfzoom)             | The default zoom level of the PDF viewer  |
-| [`latex-workshop.view.pdf.scrollMode`](#latex-workshopviewpdfscrollMode) | The default scroll mode of the PDF viewer |
-| [`latex-workshop.view.pdf.spreadMode`](#latex-workshopviewpdfspreadMode) | The default spread mode of the PDF viewer  |
-| [`latex-workshop.view.pdf.hand`](#latex-workshopviewpdfhand)             | Enable the hand tool                      |
-| [`latex-workshop.view.pdf.invert`](#latex-workshopviewpdfinvert)         | Define the CSS invert filter level        |
+| Setting key                                                                 | Description                               |
+| --------------------------------------------------------------------------- | ----------------------------------------- |
+| [`latex-workshop​.view​.pdf​.zoom`](#latex-workshopviewpdfzoom)             | The default zoom level of the PDF viewer  |
+| [`latex-workshop​.view​.pdf​.scrollMode`](#latex-workshopviewpdfscrollMode) | The default scroll mode of the PDF viewer |
+| [`latex-workshop​.view​.pdf​.spreadMode`](#latex-workshopviewpdfspreadMode) | The default spread mode of the PDF viewer |
+| [`latex-workshop​.view​.pdf​.hand`](#latex-workshopviewpdfhand)             | Enable the hand tool                      |
+| [`latex-workshop​.view​.pdf​.invert`](#latex-workshopviewpdfinvert)         | Define the CSS invert filter level        |
 
 ### latex-workshop.view.pdf.zoom
 
@@ -37,7 +37,7 @@ The default zoom level of the PDF viewer.
 
 This default value will be passed to the viewer upon opening. Possible values are `auto`, `page-actual`, `page-fit`, `page-width`, and one-based scale values (e.g., 0.5 for 50%, 2.0 for 200%).
 
-|   type   | default value |
+| type     | default value |
 | -------- | ------------- |
 | _string_ | `"auto"`      |
 
@@ -47,7 +47,7 @@ The default scroll mode of the PDF viewer.
 
 This default value will be passed to the viewer upon opening. Possible values are `0` (vertical), `1`(horizontal) and `2` (wrapped).
 
-|   type   | default value |
+| type     | default value |
 | -------- | ------------- |
 | _number_ | `0`           |
 
@@ -57,7 +57,7 @@ The default spread mode of the PDF viewer.
 
 This default value will be passed to the viewer upon opening. Possible values are `0` (none), `1` (odd) and `2` (even).
 
-|   type   | default value |
+| type     | default value |
 | -------- | ------------- |
 | _number_ | `0`           |
 
@@ -75,7 +75,7 @@ Define the CSS invert filter level of the PDF viewer.
 
 This config can invert the color of PDF. Possible values are from 0 to 1.
 
-|   type   | default value |
+| type     | default value |
 | -------- | ------------- |
 | _number_ | `0`           |
 
@@ -93,13 +93,12 @@ Synctex may fail if the path contains non-ASCII characters, see [FAQ](FAQ#Path-c
 
 ### Overview
 
-|                                        Setting key                                        |                Description                |    Default    |     Type      |
+| Setting key                                                                               | Description                               | Default       | Type          |
 | ----------------------------------------------------------------------------------------- | ----------------------------------------- | ------------- | ------------- |
 | [`latex-workshop​.synctex​.afterBuild​.enabled`](#latex-workshopsynctexafterBuildenabled) | Forward synctex at cursor after compiling | `false`       | _boolean_     |
 | [`latex-workshop​.synctex​.path`](#latex-workshopsynctexpath)                             | SyncTeX location                          | `"synctex"`   | _string_      |
 | [`latex-workshop​.view.pdf​.external​.synctex`](#latex-workshopviewpdfexternalsynctex)    | SyncTeX command for the external viewer   | (see details) | _JSON object_ |
-| [`latex-workshop.synctex.synctexjs.enabled`](#latex-workshopsynctexsynctexjsenabled)      | Enable using a built-in synctex function. | `true`       | _boolean_     |
-
+| [`latex-workshop.synctex.synctexjs.enabled`](#latex-workshopsynctexsynctexjsenabled)      | Enable using a built-in synctex function. | `true`        | _boolean_     |
 
 ## Relevant Settings
 
@@ -113,7 +112,6 @@ The following placeholders `%DOC%`, `%DOCFILE`, `%DIR%` and `%TMPDIR%` can be us
 | type     | default value |
 | -------- | ------------- |
 | _string_ | `"%DIR%"`     |
-
 
 #### latex-workshop.synctex.afterBuild.enabled
 
@@ -150,13 +148,13 @@ This builtin synctex works well even if the path of TeX files contains non-ASCII
 
 | type      | default value |
 | --------- | ------------- |
-| _boolean_ | `true`       |
+| _boolean_ | `true`        |
 
 ### latex-workshop.view.pdf.viewer
 
 The default PDF viewer.
 
-|   type   | default value                                |
+| type     | default value                                |
 | -------- | -------------------------------------------- |
 | _string_ | `"none" \| "browser" \| "tab" \| "external"` |
 
@@ -169,7 +167,7 @@ The default PDF viewer.
 
 PDF viewer used for [View on PDF] link on `\ref`.
 
-|   type   | default value                            |
+| type     | default value                            |
 | -------- | ---------------------------------------- |
 | _string_ | `"auto" \| "tabOrBrowser" \| "external"` |
 
@@ -179,6 +177,6 @@ The command to execute when using external viewer. When left empty, the default 
 
 This function is not officially supported. `%PDF%` is the placeholder for the absolute path to the generated PDF file.
 
-|     type      |         default value          |
+| type          | default value                  |
 | ------------- | ------------------------------ |
 | _JSON object_ | `{ "command": "" "args": [] }` |


### PR DESCRIPTION
I can imagine someone asking "_Zero width spaces! They sound useless - why would you want those?_".
Well, I'd usually agree with you, the wiki has a lot of long inline codeblocks in tables such as

| Setting key                                                                                                  | Description                                                                                                                                                                         | Default        | Type                                            |
| ------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- | ----------------------------------------------- |
| `latex-workshop.intellisense.citation.label`                  | Citation property used as suggestion                                                                                                                                                | `"bibtex key"` | _string_: "bibtex key" \| "title" \| "authors"  |

The issue is that line breaking doesn't occour on dots! This leads to some... funny column widths after those long codeblocks gobble up lots of room.

#### Zero width spaces to the rescue!

While zero width spaces may not change the appearance of a lone code block, they are a **space** - so word-breaking **can** occour on them.

|                                                 Setting key                                                  |                                      Description                                       |    Default     |           Type           |
| ------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------- | -------------- | ------------------------ |
| `latex-workshop​.intellisense​.citation​.label`                  | Citation property used as suggestion                                                   | `"bibtex key"` | _string_: "bibtex key" \| "title" \| "authors" |

This commit adds zero with spaces to most tables.
(Only some of the pages are here because I only changed the tables that other people added, I added a few so those ones already had this modification)