### PR TITLE
add faq on cygwin

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -21,6 +21,10 @@ The following extensions are known to cause issues when active at the same time 
 - [Brackets Pair Colorizer 2](https://marketplace.visualstudio.com/items?itemName=CoenraadS.bracket-pair-colorizer-2)
 - [Prettify Symbols Mode](https://marketplace.visualstudio.com/items?itemName=siegebell.prettify-symbols-mode)
 
+## Cygwin is not supported
+
+LaTeX Workshop does not support TeX Live installed through Cygwin. Please install TeX Live and other TeX distributions independently of Cygwin.
+
 ## The Problem Pane displays wrong messages
 
 LaTeX compilers usually produce hard wrapped log messages, which makes them really hard to parse. To hopefully deal with complex log messages, we have decided to rely on non hard wrapped log messages. This can be achieved either


### PR DESCRIPTION
TeX commands installed through Cygwin do not work at all because LaTeX Workshop does not support path resolving for Cygwin.  See James-Yu/LaTeX-Workshop/issues/1143.