### PR TITLE
add a note on magic comments in LaTeX recipes

### DIFF
--- a/Compile.md
+++ b/Compile.md
@@ -128,7 +128,7 @@ The `tools` in recipes can be defined in `latex-workshop.latex.tools`, in which 
 
 To include a tool in a recipe, the tool's `name` should be included in the recipe's `tools` list.
 
-When building the project, the first recipe is used. You can compile with another recipe by command `latex-workshop.recipes`. By default [`latexmk`](http://personal.psu.edu/jcc8/software/latexmk/) is used. This tool is bundled in most LaTeX distributions, and requires perl to execute. For non-perl users, the following `texify` toolchain from MikTeX may worth a try:
+When building the project, the [magic comments](#magic-comments) in the root file is used if given, otherwise the first recipe is used. You can compile with another recipe by command `latex-workshop.recipes`. By default [`latexmk`](http://personal.psu.edu/jcc8/software/latexmk/) is used. This tool is bundled in most LaTeX distributions, and requires perl to execute. For non-perl users, the following `texify` toolchain from MikTeX may worth a try:
 
 ```
 "latex-workshop.latex.recipes": [{


### PR DESCRIPTION
I think there's a need to indicate the priority of magic comments over default recipe.