### PR TITLE
add high CPU load issues

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -23,7 +23,7 @@
 
 ## Known incompatible Extensions
 
-The following extensions are known to cause issues when active at the same time as LaTeX-Workshop, namely a significant delay when using the Enter key in large files.
+The following extensions are known to cause issues when active at the same time as LaTeX-Workshop, namely high CPU load issues, and a significant delay when using the Enter key in large files.
 
 - [Spell Right](https://marketplace.visualstudio.com/items?itemName=ban.spellright)
 - [Brackets Pair Colorizer 2](https://marketplace.visualstudio.com/items?itemName=CoenraadS.bracket-pair-colorizer-2)


### PR DESCRIPTION
This is a PR to clarify that Spell Right causes high CPU load issues.  James-Yu/LaTeX-Workshop/issues/1196 and James-Yu/LaTeX-Workshop/issues/1260.