### PR TITLE
Fix Link to multi file projects

### DIFF
--- a/Compile.md
+++ b/Compile.md
@@ -4,7 +4,7 @@
 
 A LaTeX file is typically built by calling the command _Build LaTeX project_ from the _Command Palette_ or from the _TeX_ badge. This command is bind to <kbd>ctrl</kbd>+<kbd>alt</kbd>+<kbd>b</kbd>. If you cannot use <kbd>ctrl</kbd>+<kbd>alt</kbd> in a keybinding, see [the FAQ](FAQ#i-cannot-use-ctrlalt-in-a-shortcut). The recipe called by this command is defined by [`latex-workshop.latex.recipe.default`](#latex-workshop.latex.recipe.default).
 
-If you have a multi-file project, see [multi-files-projects](Multi-File-Projects.md) for more details on how the root file is discovered.
+If you have a multi-file project, see [multi-files-projects](Multi-File-Projects) for more details on how the root file is discovered.
 
 You can define several compiling toolchains to build LaTeX projects using [LaTeX recipes](#latex-recipes) and then call the command _Build with recipe_ to choose the appropriate toolchain for actually building the project. Alternatively, you can directly select the appropriate recipe from the _TeX_ badge.
 


### PR DESCRIPTION
The link in the wiki sent you to the raw files page instead of the formatted version. I've fixed it here. 