### PR TITLE
add doc on VS Code Remote

### DIFF
--- a/Remote.md
+++ b/Remote.md
@@ -1,0 +1,17 @@
+# VS Code Remote Development
+
+LaTeX Workshop can work with [VS Code Remote Development extensions](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack&ssr=false). You can see their [technical details](https://code.visualstudio.com/docs/remote/remote-overview). Not only you can edit a TeX file inside a Docker container or in WSL, but also you can preview the pdf file.
+
+You can also edit a TeX file on a remote server and preview the pdf file. However, when you use this feature on a remote server, please consider the following security risks.
+
+## Your TeX file can be edit by other users on the remote server
+
+VS Code Remote Development extensions start a server to host VS Code extensions on the remote server. Other users on the remote server can access the server.
+
+## Your PDF file can be read by other users on the remote server
+
+LaTeX Workshop starts a http server to preview the pdf file on the remote server. Other users on the remote server can access the server and can read your pdf file.
+
+## Summary
+
+**VS Code Remote Development extensions are NOT supposed to be used on a usual server logged in by multiple users.**

--- a/_Sidebar.md
+++ b/_Sidebar.md
@@ -44,4 +44,5 @@
   - [Navigating](Environments#Navigating)
   - [Closing the current environment](Environments#Closing-the-current-environment)
   - [Surrounding selection with an environment](Environments#Surrounding-selection-with-an-environment)
+- [VS Code Remote Development](Remote)
 - [FAQ and common issues](FAQ)


### PR DESCRIPTION
We cannot stop users from using VS Code Remote Development extensions. What we can do is warning them.