### PR TITLE
Rename texdoc variables, fix small mistake

### DIFF
--- a/Hover.md
+++ b/Hover.md
@@ -151,7 +151,7 @@ PDF viewer used for `[View on PDF]` link on hover over `\ref`, and other referen
 | -------- | ------------- | ---------------------------------------- |
 | _string_ | "auto"        | `"auto"`, `"tabOrBrowser"`, `"external"` |
 
-### latex-workshop.latex.texdoc.path
+### latex-workshop.texdoc.path
 
 Define the location of texdoc executable.
 
@@ -159,7 +159,7 @@ Define the location of texdoc executable.
 | --------- | ------------- |
 | _string_  | "texdoc"      |
 
-### latex-workshop.latex.texdoc.args
+### latex-workshop.texdoc.args
 
 Texdoc arguments to see a package documentation.
 

--- a/View.md
+++ b/View.md
@@ -312,7 +312,7 @@ This function is not officially supported. `%PDF%` is the placeholder for the ab
 
 ### latex-workshop.view.pdf.external.viewer.args
 
-This works with the `latex-workshop.pdf.external.viewer.args` to provide the arguments to the external viewer.
+This works with `latex-workshop.view.pdf.external.viewer.command` to provide the arguments to the external viewer.
 
 | type          | default value |
 | ------------- | ------------- |


### PR DESCRIPTION
#44 

- Add: `latex-workshop.texdoc.args`
- Add: `latex-workshop.texdoc.path`
- Remove: `latex-workshop.latex.texdoc.args`
- Remove: `latex-workshop.latex.texdoc.path`