### PR TITLE
Add LaTeX Preview to the list of incompatible extensions.

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -36,6 +36,7 @@ The following extensions are known to cause issues when active at the same time 
 - [Brackets Pair Colorizer 2](https://marketplace.visualstudio.com/items?itemName=CoenraadS.bracket-pair-colorizer-2): high CPU load, Enter key delay
 - [Prettify Symbols Mode](https://marketplace.visualstudio.com/items?itemName=siegebell.prettify-symbols-mode): high CPU load, Enter key delay
 - [Path Autocomplete](https://marketplace.visualstudio.com/items?itemName=ionutvmi.path-autocomplete): it may break autocompletion for bibliography citations.
+- [LaTeX Preview](https://marketplace.visualstudio.com/items?itemName=ajshort.latex-preview): Conflict with LaTeX Workshop.
 
 
 


### PR DESCRIPTION
Add LaTeX Preview to the list of incompatible extensions.
Related to
- James-Yu/LaTeX-Workshop/issues/1283 
- https://tex.stackexchange.com/questions/527463/pdf-preview-in-visual-studio-code