### PR TITLE
Add note about Flatpak related problem

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -37,6 +37,7 @@
 - [Environment variables in `.bashrc` don't take effect with VS Code Remote](#environment-variables-in-bashrc-dont-take-effect-with-vs-code-remote)
 - [Environment variables in `.zshrc` don't take effect with VS Code Remote](#environment-variables-in-zshrc-dont-take-effect-with-vs-code-remote)
 - [You cannot use a tilde `~` in `PATH`](#you-cannot-use-a-tilde--in-path)
+- [`terminal.integrated.shellArgs.linux` doesn't take effect](#terminalintegratedshellargslinux-doesnt-take-effect)
 - [Problems with Snap and Flatpak versions of VS Code](#problems-with-snap-and-flatpak-versions-of-vs-code)
 
 
@@ -282,6 +283,10 @@ After editing these files, you have to kill `vscode-server`  on the remote host 
 ## You cannot use a tilde `~` in `PATH`
 
 You can not use a tilde `~` in the environment variable `PATH` as an abbreviation of your home directory.
+
+## `terminal.integrated.shellArgs.linux` doesn't take effect
+
+The setting `terminal.integrated.shellArgs.linux` is not related to the environment variable on the extension host. You cannot set `PATH` for LaTeX Workshop through the setting.
 
 ## Problems with Snap and Flatpak versions of VS Code
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -37,6 +37,7 @@
 - [Environment variables in `.bashrc` don't take effect with VS Code Remote](#environment-variables-in-bashrc-dont-take-effect-with-vs-code-remote)
 - [Environment variables in `.zshrc` don't take effect with VS Code Remote](#environment-variables-in-zshrc-dont-take-effect-with-vs-code-remote)
 - [You cannot use a tilde `~` in `PATH`](#you-cannot-use-a-tilde--in-path)
+- [Problems with Snap and Flatpak versions of VS Code](#problems-with-snap-and-flatpak-versions-of-vs-code)
 
 
 ## Known incompatible Extensions
@@ -281,3 +282,7 @@ After editing these files, you have to kill `vscode-server`  on the remote host 
 ## You cannot use a tilde `~` in `PATH`
 
 You can not use a tilde `~` in the environment variable `PATH` as an abbreviation of your home directory.
+
+## Problems with Snap and Flatpak versions of VS Code
+
+These versions are sandboxed and are known to cause problems (e.g. [here](https://github.com/James-Yu/LaTeX-Workshop/issues/2437)). It is recommended to use other installation options, like the .deb package for Debian/Ubuntu based distributions. 

--- a/Install.md
+++ b/Install.md
@@ -20,8 +20,6 @@ If you can not fix the setting of your system, you can also override PATH with t
 
 Notice that, to set the `PATH` environment variable for VS Code Remote Development, you usually have to edit `.bash_profile` or `.profile` instead of `.bashrc`. See the [document](https://code.visualstudio.com/docs/remote/troubleshooting#_configure-the-environment-for-the-remote-extension-host) for WSL and an [issue](https://github.com/microsoft/vscode-remote-release/issues/1671#issuecomment-542818686) for Remote SSH.
 
-The Flatpak versions of [VS Code](https://github.com/flathub/com.visualstudio.code) and [VS Codium](https://github.com/flathub/com.vscodium.codium) are running inside a container and cannot access SDKs on your host system. Therefore, you might want to switch to a different distribution (e.g. deb), to mitigate problems related to the PATH environment variable. 
-
 ## Settings
 
 You can modify settings through the menu of VS Code, `Preferences > Settings`.

--- a/Install.md
+++ b/Install.md
@@ -20,6 +20,8 @@ If you can not fix the setting of your system, you can also override PATH with t
 
 Notice that, to set the `PATH` environment variable for VS Code Remote Development, you usually have to edit `.bash_profile` or `.profile` instead of `.bashrc`. See the [document](https://code.visualstudio.com/docs/remote/troubleshooting#_configure-the-environment-for-the-remote-extension-host) for WSL and an [issue](https://github.com/microsoft/vscode-remote-release/issues/1671#issuecomment-542818686) for Remote SSH.
 
+The Flatpak versions of [VS Code](https://github.com/flathub/com.visualstudio.code) and [VS Codium](https://github.com/flathub/com.vscodium.codium) are running inside a container and cannot access SDKs on your host system. Therefore, you might want to switch to a different distribution (e.g. deb), to mitigate problems related to the PATH environment variable. 
+
 ## Settings
 
 You can modify settings through the menu of VS Code, `Preferences > Settings`.


### PR DESCRIPTION
I spent a few hours on figuring out why my TeX executables were not being found until I figured out that a Flatpak version of VS Code / VS Codium is just not a good idea in this context. So this addition hopefully saves someone the frustration.