### PR TITLE
add okular synctex configuration

### DIFF
--- a/View.md
+++ b/View.md
@@ -178,6 +178,24 @@ Backward: Use `%{input}` and `%{line}` as placeholders.
 ],
 ```
 
+##### [Okular](https://apps.kde.org/en/okular) support 
+
+Add the following options to your configuration:
+
+```json
+"latex-workshop.view.pdf.viewer": "external",
+"latex-workshop.view.pdf.external.viewer.command": "okular",
+"latex-workshop.view.pdf.external.viewer.args": [
+    "--unique",
+    "%PDF%"
+],
+"latex-workshop.view.pdf.external.synctex.command": "okular",
+"latex-workshop.view.pdf.external.synctex.args": [
+    "--unique",
+    "%PDF%#src:%LINE%%TEX%"
+],
+```
+
 #### macOS
 
 ##### [Skim](https://skim-app.sourceforge.io)

--- a/View.md
+++ b/View.md
@@ -196,6 +196,8 @@ Add the following options to your configuration:
 ],
 ```
 
+Thanks to [@miterion](https://github.com/miterion) for [figuring this out](https://miterion.de/post/vscodeplusokular/).
+
 #### macOS
 
 ##### [Skim](https://skim-app.sourceforge.io)


### PR DESCRIPTION
This adds an example synctex configuration for the default pdf viewer under KDE Plasma, Okular.

original source: https://miterion.de/post/vscodeplusokular/
modified to work with current vscode / latex-workshop