### PR TITLE
Add "Path Intellisense" as incompatible extension

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -51,6 +51,7 @@ The following extensions are known to cause issues when active at the same time 
 - [Brackets Pair Colorizer 2](https://marketplace.visualstudio.com/items?itemName=CoenraadS.bracket-pair-colorizer-2): high CPU load, Enter key delay
 - [Prettify Symbols Mode](https://marketplace.visualstudio.com/items?itemName=siegebell.prettify-symbols-mode): high CPU load, Enter key delay
 - [Path Autocomplete](https://marketplace.visualstudio.com/items?itemName=ionutvmi.path-autocomplete): it may break autocompletion for bibliography citations.
+- [Path Intellisense](https://marketplace.visualstudio.com/items?itemName=christian-kohler.path-intellisense): it may break autocompletion for bibliography citations.
 - [LaTeX Preview](https://marketplace.visualstudio.com/items?itemName=ajshort.latex-preview): Conflict with LaTeX Workshop.
 - [LaTeX language support](https://marketplace.visualstudio.com/items?itemName=torn4dom4n.latex-support): It does not work with some LaTeX Workshop's snippets.
 


### PR DESCRIPTION
I found that the "[Path Intellisense](https://marketplace.visualstudio.com/items?itemName=christian-kohler.path-intellisense)" has the same effect as "[Path Autocomplete](https://marketplace.visualstudio.com/items?itemName=ionutvmi.path-autocomplete)" (breaking the bibliography completions), so I added it to the list of incompatible extensions.