### PR TITLE
Suggest LTeX for spell checking in FAQ

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -211,7 +211,7 @@ If you like to work with no sidebar in Visual Studio Code and yet the LaTeX side
 
 ## Spell check
 
-[Code Spellchecker](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker) did a great job. Users may also find other extensions better alternatives, e.g., [LanguageTool](https://marketplace.visualstudio.com/items?itemName=adamvoss.vscode-languagetool) credited for its multi-lingual support.
+[LTeX](https://marketplace.visualstudio.com/items?itemName=valentjn.vscode-ltex) is a great tool for checking spelling, grammar and style in many languages. If you only need spell checking, [Code Spellchecker](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker) does a great job, too.
 
 ## I cannot nest snippets
 


### PR DESCRIPTION
In the FAQ, you already recommend vscode-languagetool for spell and grammar checking, which is abandoned. Using the same underlying engine, there is [valentjn/vscode-ltex](https://valentjn.github.io/ltex/) and I think that should be recommended instead. Searched for an edit button in the wiki itself, thanks for pointing me here.