### PR TITLE
Add description of `latex-workshop.message.dvipdfmxlog.exclude`

### DIFF
--- a/Compile.md
+++ b/Compile.md
@@ -564,6 +564,14 @@ Exclude latex log messages matching the given regexp from the problems panel.
 | -------------------- | ------------- |
 | _array_ of _strings_ | `[]`          |
 
+### `latex-workshop.message.dvipdfmxlog.exclude`
+
+Exclude dvipdfmx log messages matching the given regexp from the problems panel.
+
+| type                 | default value |
+| -------------------- | ------------- |
+| _array_ of _strings_ | `[]`          |
+
 ### `latex-workshop.message.information.show`
 
 Display information messages in popup notifications.


### PR DESCRIPTION
The following PR added `latex-workshop.message.dvipdfmxlog.exclude`.

* https://github.com/James-Yu/LaTeX-Workshop/pull/4838

Like other settings, this setting uses regular expressions to prevent specific messages from being displayed in the Problems pane.